### PR TITLE
Fix instructions column type

### DIFF
--- a/models.py
+++ b/models.py
@@ -44,7 +44,7 @@ class Recipe(Base):
     id = Column(String, primary_key=True, default=get_uuid)
     title = Column(String, index=True)
     ingredients = Column(String)
-    instructions = Column(Integer)
+    instructions = Column(String)
     cook_time = Column(String)
     difficulty = Column(String)
     image_url = Column(String)


### PR DESCRIPTION
## Summary
- correct the `instructions` field type to `String` in `models.py`

## Testing
- `pytest -q`
- ⚠️ `python` commands failed due to missing dependencies

------
https://chatgpt.com/codex/tasks/task_e_6847a3204460832984c64c9693e4fbe8